### PR TITLE
Add a CLI

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -30,10 +30,16 @@ def emit_toml(deps):
     print("]")
 
 
-def emit_pep723(deps):
+def emit_inline(deps):
     print("""# ///\n# requires-python = ">=3.8"\n# dependencies = [""")
     print(*map(lambda d: f'#     "{d}",', sorted(deps)), sep="\n")
     print("# ]\n# ///")
+
+
+def emit_python(deps):
+    print("""__requires__ = [""")
+    print(*map(lambda d: f'    "{d}",', sorted(deps)), sep="\n")
+    print("]")
 
 
 def parse_glob(spec: str):

--- a/__main__.py
+++ b/__main__.py
@@ -11,35 +11,47 @@ Options:
 For each file matching the globs, parses dependencies and emits them in the requested format.
 """
 
-import sys
-import pathlib
-import glob
 import argparse
-from .imports import get_module_imports, Import
-from .pypi import distribution_for, NoDistributionForImport
+import glob
+import pathlib
+import sys
+
+from .imports import Import, get_module_imports
+from .pypi import NoDistributionForImport, distribution_for
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Emit dependencies for Python files.")
     parser.add_argument("globs", nargs="+", help="File globs to process")
-    parser.add_argument("--format", choices=["plain", "toml", "pep723"], default="plain", help="Output format")
+    parser.add_argument(
+        "--format",
+        choices=["plain", "toml", "pep723"],
+        default="plain",
+        help="Output format",
+    )
     return parser.parse_args()
+
 
 def emit_plain(deps):
     print(*sorted(deps), sep="\n")
+
 
 def emit_toml(deps):
     print("[project]\nrequires = [")
     print(*map(lambda d: f'    "{d}",', sorted(deps)), sep="\n")
     print("]")
 
+
 def emit_pep723(deps):
     print("""# ///\n# requires-python = ">=3.8"\n# dependencies = [""")
     print(*map(lambda d: f'#     "{d}",', sorted(deps)), sep="\n")
     print("# ]\n# ///")
 
+
 def main():
     args = parse_args()
     files = set().union(*map(lambda pat: glob.glob(pat, recursive=True), args.globs))
+
     def import_to_dep(name):
         imp = Import(name)
         if imp.excluded():
@@ -48,15 +60,20 @@ def main():
             return distribution_for(imp.top)
         except NoDistributionForImport:
             return None
+
     def file_deps(file):
         try:
-            return filter(None, map(import_to_dep, get_module_imports(pathlib.Path(file))))
+            return filter(
+                None, map(import_to_dep, get_module_imports(pathlib.Path(file)))
+            )
         except Exception as e:
             print(f"Error processing {file}: {e}", file=sys.stderr)
             return []
+
     deps = set(filter(None, (dep for file in files for dep in file_deps(file))))
     emit = dict(plain=emit_plain, toml=emit_toml, pep723=emit_pep723)[args.format]
     emit(deps)
+
 
 if __name__ == "__main__":
     main()

--- a/__main__.py
+++ b/__main__.py
@@ -5,9 +5,6 @@ Usage:
     pipx run coherent.deps [options] <glob> [<glob> ...]
     py -m coherent.deps [options] <glob> [<glob> ...]
 
-Options:
-    --format=plain|toml|pep723   Output format (default: plain)
-
 For each file matching the globs, parses dependencies and emits them in the requested format.
 """
 

--- a/__main__.py
+++ b/__main__.py
@@ -21,24 +21,24 @@ from . import imports, pypi
 
 
 def emit_plain(deps):
-    print(*sorted(deps), sep="\n")
+    print(*deps, sep="\n")
 
 
 def emit_toml(deps):
     print("[project]\nrequires = [")
-    print(*map(lambda d: f'    "{d}",', sorted(deps)), sep="\n")
+    print(*map(lambda d: f'    "{d}",', deps), sep="\n")
     print("]")
 
 
 def emit_inline(deps):
     print("""# ///\n# requires-python = ">=3.8"\n# dependencies = [""")
-    print(*map(lambda d: f'#     "{d}",', sorted(deps)), sep="\n")
+    print(*map(lambda d: f'#     "{d}",', deps), sep="\n")
     print("# ]\n# ///")
 
 
 def emit_python(deps):
     print("""__requires__ = [""")
-    print(*map(lambda d: f'    "{d}",', sorted(deps)), sep="\n")
+    print(*map(lambda d: f'    "{d}",', deps), sep="\n")
     print("]")
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -12,13 +12,11 @@ For each file matching the globs, parses dependencies and emits them in the requ
 """
 
 import pathlib
-import sys
 
 from jaraco.ui.main import main
 from more_itertools import flatten
 
-from .imports import Import, get_module_imports
-from .pypi import NoDistributionForImport, distribution_for
+from . import imports, pypi
 
 
 def emit_plain(deps):
@@ -47,26 +45,7 @@ def main(
     globs: list[str],
     format: str = 'plain',
 ):
-    files = list(flatten(map(pathlib.Path().glob, globs)))
-
-    def import_to_dep(name):
-        imp = Import(name)
-        if imp.excluded():
-            return None
-        try:
-            return distribution_for(imp.top)
-        except NoDistributionForImport:
-            return None
-
-    def file_deps(file):
-        try:
-            return filter(
-                None, map(import_to_dep, get_module_imports(pathlib.Path(file)))
-            )
-        except Exception as e:
-            print(f"Error processing {file}: {e}", file=sys.stderr)
-            return []
-
-    deps = set(filter(None, (dep for file in files for dep in file_deps(file))))
-    emit = globals()[f'emit_{format}']
-    emit(deps)
+    files = flatten(map(pathlib.Path().glob, globs))
+    imps = flatten(map(imports.get_module_imports, files))
+    deps = (pypi.distribution_for(imp) for imp in imps if not imp.excluded())
+    globals()[f'emit_{format}'](deps)

--- a/__main__.py
+++ b/__main__.py
@@ -11,25 +11,14 @@ Options:
 For each file matching the globs, parses dependencies and emits them in the requested format.
 """
 
-import argparse
-import glob
+import itertools
 import pathlib
 import sys
 
+from jaraco.ui.main import main
+
 from .imports import Import, get_module_imports
 from .pypi import NoDistributionForImport, distribution_for
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Emit dependencies for Python files.")
-    parser.add_argument("globs", nargs="+", help="File globs to process")
-    parser.add_argument(
-        "--format",
-        choices=["plain", "toml", "pep723"],
-        default="plain",
-        help="Output format",
-    )
-    return parser.parse_args()
 
 
 def emit_plain(deps):
@@ -48,9 +37,20 @@ def emit_pep723(deps):
     print("# ]\n# ///")
 
 
-def main():
-    args = parse_args()
-    files = set().union(*map(lambda pat: glob.glob(pat, recursive=True), args.globs))
+def parse_glob(glob):
+    print(glob)
+    return glob
+
+
+flatten = itertools.chain.from_iterable
+
+
+@main
+def main(
+    globs: list[str],
+    format: str = 'plain',
+):
+    files = list(flatten(map(pathlib.Path().glob, globs)))
 
     def import_to_dep(name):
         imp = Import(name)
@@ -71,9 +71,5 @@ def main():
             return []
 
     deps = set(filter(None, (dep for file in files for dep in file_deps(file))))
-    emit = dict(plain=emit_plain, toml=emit_toml, pep723=emit_pep723)[args.format]
+    emit = dict(plain=emit_plain, toml=emit_toml, pep723=emit_pep723)[format]
     emit(deps)
-
-
-if __name__ == "__main__":
-    main()

--- a/__main__.py
+++ b/__main__.py
@@ -15,31 +15,31 @@ import glob
 import pathlib
 
 from jaraco.ui.main import main
-from more_itertools import flatten
+from more_itertools import consume, flatten
 
 from . import imports, pypi
 
 
 def emit_plain(deps):
-    print(*deps, sep="\n")
+    yield from deps
 
 
 def emit_toml(deps):
-    print("[project]\nrequires = [")
-    print(*map(lambda d: f'    "{d}",', deps), sep="\n")
-    print("]")
+    yield "[project]\nrequires = ["
+    yield from map(lambda d: f'    "{d}",', deps)
+    yield "]"
 
 
 def emit_inline(deps):
-    print("""# ///\n# requires-python = ">=3.8"\n# dependencies = [""")
-    print(*map(lambda d: f'#     "{d}",', deps), sep="\n")
-    print("# ]\n# ///")
+    yield """# ///\n# requires-python = ">=3.8"\n# dependencies = ["""
+    yield from map(lambda d: f'#     "{d}",', deps)
+    yield "# ]\n# ///"
 
 
 def emit_python(deps):
-    print("""__requires__ = [""")
-    print(*map(lambda d: f'    "{d}",', deps), sep="\n")
-    print("]")
+    yield """__requires__ = ["""
+    yield from map(lambda d: f'    "{d}",', deps)
+    yield "]"
 
 
 def parse_glob(spec: str):
@@ -54,4 +54,5 @@ def main(
     files = flatten(map(parse_glob, globs))
     imps = flatten(map(imports.get_module_imports, files))
     deps = (pypi.distribution_for(imp) for imp in imps if not imp.excluded())
-    globals()[f'emit_{format}'](deps)
+    lines = globals()[f'emit_{format}'](deps)
+    consume(map(print, lines))

--- a/__main__.py
+++ b/__main__.py
@@ -71,5 +71,5 @@ def main(
             return []
 
     deps = set(filter(None, (dep for file in files for dep in file_deps(file))))
-    emit = dict(plain=emit_plain, toml=emit_toml, pep723=emit_pep723)[format]
+    emit = globals()[f'emit_{format}']
     emit(deps)

--- a/__main__.py
+++ b/__main__.py
@@ -11,11 +11,11 @@ Options:
 For each file matching the globs, parses dependencies and emits them in the requested format.
 """
 
-import itertools
 import pathlib
 import sys
 
 from jaraco.ui.main import main
+from more_itertools import flatten
 
 from .imports import Import, get_module_imports
 from .pypi import NoDistributionForImport, distribution_for
@@ -40,9 +40,6 @@ def emit_pep723(deps):
 def parse_glob(glob):
     print(glob)
     return glob
-
-
-flatten = itertools.chain.from_iterable
 
 
 @main

--- a/__main__.py
+++ b/__main__.py
@@ -11,6 +11,7 @@ Options:
 For each file matching the globs, parses dependencies and emits them in the requested format.
 """
 
+import glob
 import pathlib
 
 from jaraco.ui.main import main
@@ -35,9 +36,8 @@ def emit_pep723(deps):
     print("# ]\n# ///")
 
 
-def parse_glob(glob):
-    print(glob)
-    return glob
+def parse_glob(spec: str):
+    return map(pathlib.Path, glob.glob(spec))
 
 
 @main
@@ -45,7 +45,7 @@ def main(
     globs: list[str],
     format: str = 'plain',
 ):
-    files = flatten(map(pathlib.Path().glob, globs))
+    files = flatten(map(parse_glob, globs))
     imps = flatten(map(imports.get_module_imports, files))
     deps = (pypi.distribution_for(imp) for imp in imps if not imp.excluded())
     globals()[f'emit_{format}'](deps)

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,62 @@
+"""
+CLI for coherent.deps: emits dependencies for Python files given as globs.
+
+Usage:
+    pipx run coherent.deps [options] <glob> [<glob> ...]
+    py -m coherent.deps [options] <glob> [<glob> ...]
+
+Options:
+    --format=plain|toml|pep723   Output format (default: plain)
+
+For each file matching the globs, parses dependencies and emits them in the requested format.
+"""
+
+import sys
+import pathlib
+import glob
+import argparse
+from .imports import get_module_imports, Import
+from .pypi import distribution_for, NoDistributionForImport
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Emit dependencies for Python files.")
+    parser.add_argument("globs", nargs="+", help="File globs to process")
+    parser.add_argument("--format", choices=["plain", "toml", "pep723"], default="plain", help="Output format")
+    return parser.parse_args()
+
+def emit_plain(deps):
+    print(*sorted(deps), sep="\n")
+
+def emit_toml(deps):
+    print("[project]\nrequires = [")
+    print(*map(lambda d: f'    "{d}",', sorted(deps)), sep="\n")
+    print("]")
+
+def emit_pep723(deps):
+    print("""# ///\n# requires-python = ">=3.8"\n# dependencies = [""")
+    print(*map(lambda d: f'#     "{d}",', sorted(deps)), sep="\n")
+    print("# ]\n# ///")
+
+def main():
+    args = parse_args()
+    files = set().union(*map(lambda pat: glob.glob(pat, recursive=True), args.globs))
+    def import_to_dep(name):
+        imp = Import(name)
+        if imp.excluded():
+            return None
+        try:
+            return distribution_for(imp.top)
+        except NoDistributionForImport:
+            return None
+    def file_deps(file):
+        try:
+            return filter(None, map(import_to_dep, get_module_imports(pathlib.Path(file))))
+        except Exception as e:
+            print(f"Error processing {file}: {e}", file=sys.stderr)
+            return []
+    deps = set(filter(None, (dep for file in files for dep in file_deps(file))))
+    emit = dict(plain=emit_plain, toml=emit_toml, pep723=emit_pep723)[args.format]
+    emit(deps)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #16

- **Adding an initial CLI entry point.**
- **👹 Feed the hobgoblins (delint).**
- **Utilize typer for parsing args.**
- **Resolve the emitter directly**
- **Use flatten from more_itertools.**
- **Collapse the behavior to a few operations.**
- **Fix glob parsing when it's absolute.**
- **Rename pep723 to inline, and add python.**
- **No need to sort.**
- **Use emit to yield lines, and render the lines in one place.**
- **Remove stale docstring.**
