### PR TITLE
Recognize platform-specific stdlib modules (e.g. winreg) as standard

### DIFF
--- a/imports.py
+++ b/imports.py
@@ -78,8 +78,17 @@ class Import(str):
         False
         >>> Import('.os').standard()
         False
+
+        Platform-specific stdlib modules are recognized as standard even
+        when they're not importable on the current host (e.g. ``winreg``
+        on non-Windows).
+
+        >>> Import('winreg').standard()
+        True
         """
-        return bool(self.top) and self._check_standard(self.top)
+        return bool(self.top) and (
+            self.top in sys.stdlib_module_names or self._check_standard(self.top)
+        )
 
     @property
     def top(self) -> str | None:


### PR DESCRIPTION
Closes #21.

`Import.standard()` decided "is this stdlib?" by importing the top-level name in a clean interpreter **on the current host**, so Windows-only stdlib modules (`winreg`, `msvcrt`, `_winapi`, …) were misclassified as third-party on macOS/Linux. `coherent.build`'s `inferred_deps()` then raised `NoDistributionForImport: winreg` during `prepare_metadata_for_build_wheel`, blocking builds of any package that imports such a module (e.g. `compilers.C`, whose `msvc.py` imports `winreg`) on non-Windows hosts.

Fix: short-circuit `standard()` on [`sys.stdlib_module_names`](https://docs.python.org/3/library/sys.html#sys.stdlib_module_names) — a frozenset that is identical on every platform and *does* include the platform-specific modules — falling back to the existing runtime import check. Additive and platform-independent; nothing already classified correctly changes. Added a `Import('winreg').standard()` doctest.

`sys.stdlib_module_names` is available on Python ≥ 3.10, already the floor for the coherent stack.