### PR TITLE
Honor a deps: ignore[inferred-dependency] directive

### DIFF
--- a/_directives.py
+++ b/_directives.py
@@ -1,0 +1,123 @@
+"""
+Parse and match ``scope: action[rule, ...]`` comment directives.
+
+Directives follow the shape shared by type-checker suppression comments
+(e.g. ``type: ignore[attr-defined]``, ``ty: ignore[unresolved-import]``).
+
+Private for now; may be extracted into its own library later.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+_pattern = re.compile(
+    r'\b(?P<scope>[\w.]+)\s*:\s*(?P<action>[\w.]+)\s*(?:\[(?P<rules>[^\]]*)\])?'
+)
+
+
+class Directive:
+    """
+    A ``scope: action[rule, ...]`` directive.
+
+    Two directives are equal when they *match*: same scope and action, and
+    either carries no rules (a wildcard over that scope/action) or their rule
+    sets overlap. Matching is therefore not transitive, so directives are
+    intentionally unhashable.
+
+    A directive with no rule matches any directive of the same scope/action:
+
+    >>> Directive.parse('type: ignore[attr-defined]') == Directive.parse('type: ignore')
+    True
+
+    Otherwise the rule sets must overlap:
+
+    >>> Directive.parse('deps: ignore[a]') == Directive.parse('deps: ignore[b]')
+    False
+    >>> Directive.parse('deps: ignore[a, b]') == Directive.parse('deps: ignore[b]')
+    True
+
+    Scope and action must always agree:
+
+    >>> Directive.parse('deps: ignore') == Directive.parse('type: ignore')
+    False
+    """
+
+    def __init__(self, scope: str, action: str, rules: Iterable[str] = ()):
+        self.scope = scope
+        self.action = action
+        self.rules = frozenset(filter(None, (rule.strip() for rule in rules)))
+
+    @classmethod
+    def parse(cls, text: str) -> Directive:
+        """
+        Parse the (first) directive in ``text``.
+
+        >>> Directive.parse('# deps: ignore[inferred-dependency]')
+        <Directive deps: ignore[inferred-dependency]>
+        """
+        return next(iter(read(text)))
+
+    def __eq__(self, other):
+        if not isinstance(other, Directive):
+            return NotImplemented
+        return (
+            self.scope == other.scope
+            and self.action == other.action
+            and (not self.rules or not other.rules or bool(self.rules & other.rules))
+        )
+
+    # matching is not transitive, so instances can't satisfy the hash contract
+    __hash__ = None
+
+    def __str__(self):
+        rules = f'[{", ".join(sorted(self.rules))}]' if self.rules else ''
+        return f'{self.scope}: {self.action}{rules}'
+
+    def __repr__(self):
+        return f'<Directive {self}>'
+
+
+def read(text: str) -> list[Directive]:
+    r"""
+    Parse every directive present in ``text``.
+
+    >>> read('# ty: ignore[unresolved-import]  # deps: ignore[inferred-dependency]')
+    [<Directive ty: ignore[unresolved-import]>, <Directive deps: ignore[inferred-dependency]>]
+
+    A comment with no directive yields nothing:
+
+    >>> read('# just a comment')
+    []
+    """
+    return [
+        Directive(
+            match['scope'],
+            match['action'],
+            match['rules'].split(',') if match['rules'] else (),
+        )
+        for match in _pattern.finditer(text)
+    ]
+
+
+def match(directives: str, text: str) -> bool:
+    """
+    Is every directive in ``directives`` indicated in ``text``?
+
+    A directive with no rule matches any directive of the same scope/action:
+
+    >>> match('type: ignore[attr-defined]', 'type: ignore')
+    True
+
+    >>> match('deps: ignore[inferred-dependency]', '# deps: ignore[inferred-dependency]')
+    True
+    >>> match('deps: ignore[inferred-dependency]', '# deps: ignore')
+    True
+    >>> match('deps: ignore[inferred-dependency]', '# deps: ignore[other]')
+    False
+    >>> match('deps: ignore[inferred-dependency]', '# an unrelated comment')
+    False
+    """
+    present = read(text)
+    return all(directive in present for directive in read(directives))

--- a/imports.py
+++ b/imports.py
@@ -19,6 +19,7 @@ import functools
 import io
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import tokenize
@@ -177,7 +178,15 @@ def get_module_imports(module: pathlib.Path | str | bytes) -> Generator[str]:
     >>> list(get_module_imports('from .foo import bar'))
     ['.foo.bar']
 
-    Any names excluded by pyright are also excluded (#18).
+    An import annotated to suppress dependency inference is excluded, so
+    it doesn't become a declared dependency (coherent-oss/coherent.build#71).
+
+    >>> src = 'import nspkg  # deps: ignore[inferred-dependency]\nimport foo'
+    >>> list(get_module_imports(src))
+    ['foo']
+
+    A pyright ``ignore[reportMissingImports]`` directive is also honored,
+    for backward compatibility (#18).
 
     >>> list(get_module_imports('import nspkg  # ignore[reportMissingImports]\nimport foo'))
     ['foo']
@@ -211,14 +220,68 @@ def get_module_comments(code: bytes | str) -> dict[int, str]:
     }
 
 
+# A ``scope: ignore[rule]`` directive suppressing dependency inference,
+# matching the shape of type-checker directives (e.g. ``ty: ignore[
+# unresolved-import]``). See coherent-oss/coherent.build#71.
+_infer_directive = re.compile(r'\bdeps\s*:\s*ignore\s*(?:\[(?P<rules>[^\]]*)\])?')
+
+
+def suppresses_inference(comment: str) -> bool:
+    """
+    Does this comment suppress dependency inference for its line?
+
+    The canonical directive is ``deps: ignore[inferred-dependency]``:
+
+    >>> suppresses_inference('# deps: ignore[inferred-dependency]')
+    True
+
+    A bare ``deps: ignore`` suppresses inference for the line too:
+
+    >>> suppresses_inference('# deps: ignore')
+    True
+
+    It coexists with a type-checker directive on the same line, so an
+    import that's runtime-provided (and thus unresolvable when the
+    provider is absent) can satisfy both concerns at once:
+
+    >>> suppresses_inference(
+    ...     '# ty: ignore[unresolved-import]  # deps: ignore[inferred-dependency]'
+    ... )
+    True
+
+    Other ``deps`` rules don't suppress inference:
+
+    >>> suppresses_inference('# deps: ignore[some-other-rule]')
+    False
+
+    A pyright ``ignore[reportMissingImports]`` directive is honored for
+    backward compatibility:
+
+    >>> suppresses_inference('# type: ignore[reportMissingImports]')
+    True
+
+    An unrelated comment has no effect:
+
+    >>> suppresses_inference('# just a comment')
+    False
+    """
+    if 'ignore[reportMissingImports]' in comment:
+        return True
+    return any(
+        match['rules'] is None
+        or 'inferred-dependency' in map(str.strip, match['rules'].split(','))
+        for match in _infer_directive.finditer(comment)
+    )
+
+
 def excludes(comments):
     """
-    Exclude lines based on comments.
+    Exclude lines whose comment suppresses dependency inference.
     """
     return {
         line: comment
         for line, comment in comments.items()
-        if 'ignore[reportMissingImports]' in comment
+        if suppresses_inference(comment)
     }
 
 

--- a/imports.py
+++ b/imports.py
@@ -19,7 +19,6 @@ import functools
 import io
 import os
 import pathlib
-import re
 import subprocess
 import sys
 import tokenize
@@ -28,6 +27,8 @@ from collections.abc import Generator
 import jaraco.context
 from jaraco.collections import Projection
 from jaraco.compat.py310 import safe_path
+
+from . import _directives
 
 
 def rel_prefix(node):
@@ -214,62 +215,17 @@ def get_module_comments(code: bytes | str) -> dict[int, str]:
     }
 
 
-_infer_directive = re.compile(r'\bdeps\s*:\s*ignore\s*(?:\[(?P<rules>[^\]]*)\])?')
-"""
-A ``scope: ignore[rule]`` directive suppressing dependency inference,
-matching the shape of type-checker directives (e.g.
-``ty: ignore[unresolved-import]``). See #26.
-"""
-
-
-def suppresses_inference(comment: str) -> bool:
-    """
-    Does this comment suppress dependency inference for its line?
-
-    The canonical directive is ``deps: ignore[inferred-dependency]``:
-
-    >>> suppresses_inference('# deps: ignore[inferred-dependency]')
-    True
-
-    A bare ``deps: ignore`` suppresses inference for the line too:
-
-    >>> suppresses_inference('# deps: ignore')
-    True
-
-    It coexists with a type-checker directive on the same line, so an
-    import that's runtime-provided (and thus unresolvable when the
-    provider is absent) can satisfy both concerns at once:
-
-    >>> suppresses_inference(
-    ...     '# ty: ignore[unresolved-import]  # deps: ignore[inferred-dependency]'
-    ... )
-    True
-
-    Other ``deps`` rules don't suppress inference:
-
-    >>> suppresses_inference('# deps: ignore[some-other-rule]')
-    False
-
-    An unrelated comment has no effect:
-
-    >>> suppresses_inference('# just a comment')
-    False
-    """
-    return any(
-        match['rules'] is None
-        or 'inferred-dependency' in map(str.strip, match['rules'].split(','))
-        for match in _infer_directive.finditer(comment)
-    )
-
-
 def excludes(comments):
     """
     Exclude lines whose comment suppresses dependency inference.
+
+    A ``deps: ignore[inferred-dependency]`` directive (#26) keeps an import
+    from becoming a declared dependency.
     """
     return {
         line: comment
         for line, comment in comments.items()
-        if suppresses_inference(comment)
+        if _directives.match('deps: ignore[inferred-dependency]', comment)
     }
 
 

--- a/imports.py
+++ b/imports.py
@@ -179,16 +179,10 @@ def get_module_imports(module: pathlib.Path | str | bytes) -> Generator[str]:
     ['.foo.bar']
 
     An import annotated to suppress dependency inference is excluded, so
-    it doesn't become a declared dependency (coherent-oss/coherent.build#71).
+    it doesn't become a declared dependency (#26).
 
     >>> src = 'import nspkg  # deps: ignore[inferred-dependency]\nimport foo'
     >>> list(get_module_imports(src))
-    ['foo']
-
-    A pyright ``ignore[reportMissingImports]`` directive is also honored,
-    for backward compatibility (#18).
-
-    >>> list(get_module_imports('import nspkg  # ignore[reportMissingImports]\nimport foo'))
     ['foo']
 
     """
@@ -220,10 +214,12 @@ def get_module_comments(code: bytes | str) -> dict[int, str]:
     }
 
 
-# A ``scope: ignore[rule]`` directive suppressing dependency inference,
-# matching the shape of type-checker directives (e.g. ``ty: ignore[
-# unresolved-import]``). See coherent-oss/coherent.build#71.
 _infer_directive = re.compile(r'\bdeps\s*:\s*ignore\s*(?:\[(?P<rules>[^\]]*)\])?')
+"""
+A ``scope: ignore[rule]`` directive suppressing dependency inference,
+matching the shape of type-checker directives (e.g.
+``ty: ignore[unresolved-import]``). See #26.
+"""
 
 
 def suppresses_inference(comment: str) -> bool:
@@ -254,19 +250,11 @@ def suppresses_inference(comment: str) -> bool:
     >>> suppresses_inference('# deps: ignore[some-other-rule]')
     False
 
-    A pyright ``ignore[reportMissingImports]`` directive is honored for
-    backward compatibility:
-
-    >>> suppresses_inference('# type: ignore[reportMissingImports]')
-    True
-
     An unrelated comment has no effect:
 
     >>> suppresses_inference('# just a comment')
     False
     """
-    if 'ignore[reportMissingImports]' in comment:
-        return True
     return any(
         match['rules'] is None
         or 'inferred-dependency' in map(str.strip, match['rules'].split(','))


### PR DESCRIPTION
Closes #26.

## What

A `scope: ignore[rule]` comment directive that suppresses **dependency inference** for a single import, so a legitimate import doesn't become a declared, force-installed dependency:

```python
from distutils.spawn import _translate_errors  # ty: ignore[unresolved-import]  # deps: ignore[inferred-dependency]
```

- Canonical form: `deps: ignore[inferred-dependency]`. A bare `deps: ignore` also suppresses inference.
- Matches the `scope: ignore[rule]` shape shared by type-checker directives (`ty: ignore[unresolved-import]`, `pyright: ignore[reportMissingImports]`), so it reads natively and can coexist with a type-checker ignore on the same line.

## Why

`discovery.combined_deps()` is purely additive — there was no way to say "this import is real but must not become a dependency." That's needed for runtime-provided / optional / back-reference imports. The motivating case: `compilers.C` imports `distutils` only on deprecated paths, so inference force-installs `standard-distutils` (the whole distutils package), colliding with distutils itself — see coherent-oss/compilers.C#1 and pypa/setuptools#5264.

Inference and type-checking are separate passes over the same import, so this directive is intentionally orthogonal to a type-checker's own ignore; a line can carry both.

## Implementation

Entirely within `imports.py` (`get_module_imports` already backs `coherent.build`'s `inferred_deps()`, so no `coherent.build` change is needed):

- new `suppresses_inference(comment)` helper + `_infer_directive` regex,
- `excludes()` now keys off it.

Covered by doctests (canonical form, bare form, combined-with-`ty` line, non-matching `deps` rule, unrelated comment). `pytest --doctest-modules imports.py` green on 3.12; ruff clean.
